### PR TITLE
monotime: Implement a monotonic time source.

### DIFF
--- a/monotime/monotime.go
+++ b/monotime/monotime.go
@@ -1,0 +1,29 @@
+// monotime.go - Monotonic clock.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package monotime implements a monotonic clock.
+package monotime
+
+import (
+	"time"
+)
+
+// Now returns the current time as measured by a monotonic clock source.  The
+// value is totally unrelated to civil time, and should only be used for
+// measuring relative time intervals.
+func Now() time.Duration {
+	return nowImpl()
+}

--- a/monotime/monotime_fallback.go
+++ b/monotime/monotime_fallback.go
@@ -1,0 +1,25 @@
+// monotime_fallback.go - Fallback "monotonic" clock.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// +build !linux
+
+package monotime
+
+import "time"
+
+func nowImpl() time.Duration {
+	return time.Duration(time.Now().UnixNano()) * time.Nanosecond
+}

--- a/monotime/monotime_linux.go
+++ b/monotime/monotime_linux.go
@@ -1,0 +1,52 @@
+// monotime_linux.go - Linux Monotonic clock.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package monotime
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+var (
+	vdsoClockGettime uintptr
+	useVDSO          = false
+)
+
+func nowImpl() time.Duration {
+	const clockMonotonicRaw = 4
+
+	var ts syscall.Timespec
+	res := uintptr(unsafe.Pointer(&ts))
+
+	if useVDSO {
+		vdsoClockGettimeTrampoline(clockMonotonicRaw, res, vdsoClockGettime)
+	} else {
+		_, _, e1 := syscall.Syscall(syscall.SYS_CLOCK_GETTIME, clockMonotonicRaw, res, 0)
+		if e1 != 0 {
+			panic("monotime: clock_gettime(CLOCK_MONOTONIC_RAW, &ts): " + e1.Error())
+		}
+	}
+
+	return time.Duration(ts.Nano()) * time.Nanosecond
+}
+
+func init() {
+	if err := initArchDep(); err == nil {
+		useVDSO = true
+	}
+}

--- a/monotime/monotime_linux_amd64.go
+++ b/monotime/monotime_linux_amd64.go
@@ -1,0 +1,134 @@
+// monotime_linux_amd64.go - Linux AMD64 Monotonic clock.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// +build !noasm
+
+package monotime
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"io/ioutil"
+	"os"
+	"unsafe"
+)
+
+func getSysinfoEhdr() (uintptr, error) {
+	const AT_SYSINFO_EHDR = 33
+
+	auxv, err := ioutil.ReadFile("/proc/self/auxv")
+	if err != nil {
+		return 0, err
+	}
+
+	for i := 0; i < len(auxv)/(8*2); i++ {
+		id := binary.LittleEndian.Uint64(auxv[i*16:])
+		val := binary.LittleEndian.Uint64(auxv[i*16+8:])
+		if id == AT_SYSINFO_EHDR {
+			return uintptr(val), nil
+		}
+	}
+
+	return 0, nil
+}
+
+//go:noescape
+//go:nosplit
+func vdsoClockGettimeTrampoline(clkID uint64, res uintptr, fn uintptr)
+
+func initArchDep() error {
+	// A trivial vDSO parser based on the CC0 parse_vdso.c in the Linux source
+	// tree.
+
+	const symClockGettime = "clock_gettime"
+
+	// Find the vDSO base, if present.
+	base, err := getSysinfoEhdr()
+	if err != nil {
+		return err
+	} else if base == 0 {
+		return errors.New("monotime: ELF AT_SYSINFO_EHDR missing")
+	}
+
+	// Shadow the vDSO pages.  This is hilariously unsafe.
+	vDSOPage := make([]byte, os.Getpagesize()*2)
+	for i := range vDSOPage {
+		ptr := (*byte)(unsafe.Pointer(base + uintptr(i)))
+		vDSOPage[i] = *ptr
+	}
+
+	f, err := elf.NewFile(bytes.NewReader(vDSOPage))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Find the PT_LOAD and store the load offset.
+	loadOffset := uintptr(0)
+	for _, v := range f.Progs {
+		if v.Type == elf.PT_LOAD {
+			loadOffset = base + uintptr(v.Off) + uintptr(v.Vaddr)
+			break
+		}
+	}
+	if loadOffset == 0 {
+		return errors.New("monotime: Failed to find ELF PT_LOAD")
+	}
+
+	// Find the VERSYM and VERDEF sections.
+	verSym := f.SectionByType(elf.SHT_GNU_VERSYM)
+	if verSym == nil {
+		return errors.New("monotime: Failed to find ELF SHT_GNU_VERSYM")
+	}
+	verDef := f.SectionByType(elf.SHT_GNU_VERDEF)
+	if verDef == nil {
+		return errors.New("monotime: Failed to find ELF SHT_GNU_VERDEF")
+	}
+
+	syms, err := f.DynamicSymbols()
+	if err != nil {
+		return err
+	}
+	for _, v := range syms {
+		if v.Name == symClockGettime {
+			// Ensure the correct type and binding.
+			if elf.ST_TYPE(v.Info) != elf.STT_FUNC {
+				continue
+			}
+			switch elf.ST_BIND(v.Info) {
+			case elf.STB_WEAK, elf.STB_GLOBAL:
+				break
+			default:
+				continue
+			}
+			if v.Section == elf.SHN_UNDEF {
+				continue
+			}
+
+			// XXX: Validate the version. ("LINUX_2.6").  In theory this needs
+			// to happen.  Go's ELF parser package actually has most of what's
+			// needed here, but not exported, and incomplete.  YOLO.
+
+			// Save the vdso clock_gettime() address.
+			vdsoClockGettime = loadOffset + uintptr(v.Value)
+			return nil
+		}
+	}
+
+	return errors.New("monotime: Failed to find vDSO clock_gettime")
+}

--- a/monotime/monotime_linux_amd64.s
+++ b/monotime/monotime_linux_amd64.s
@@ -1,0 +1,26 @@
+// monotime_linux_amd64.s - Linux AMD64 vDSO trampoline.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// +build !noasm
+
+#include "textflag.h"
+
+TEXT ·vdsoClockGettimeTrampoline(SB),NOSPLIT,$0-24
+	MOVQ clkID+0(FP), DI
+	MOVQ res+8(FP), SI
+	MOVQ fn+16(FP), AX
+	CALL AX
+	RET

--- a/monotime/monotime_linux_generic.go
+++ b/monotime/monotime_linux_generic.go
@@ -1,0 +1,30 @@
+// monotime_linux_generic.go - Generic Linux stubs.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// +build linux,!amd64
+// +build linux,amd64,noasm
+
+package monotime
+
+import "errors"
+
+func vdsoClockGettimeTrampoline(clkID uint64, res uintptr, fn uintptr) {
+	panic("monotime: vDSO call on unsupported architecture")
+}
+
+func initArchDep() error {
+	return errors.New("monotime: unsupported architecture for vDSO calls")
+}

--- a/monotime/monotime_test.go
+++ b/monotime/monotime_test.go
@@ -1,0 +1,41 @@
+// monotime_test.go - Monotonic clock tests.
+// Copyright (C) 2017  Yawning Angel.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package monotime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonotime(t *testing.T) {
+	require := require.New(t)
+
+	// Ensure that using the monotonic clock source actually appears to work.
+	require.NotPanics(func() { Now() }, "Basic Now() sanity check")
+
+	// Validate timekeeping, by sleeping for a fixed interval and ensuring that
+	// the monotonic clock advances by approximately how much we expect.
+	const sleepTime = 100 * time.Millisecond
+
+	before := Now()
+	time.Sleep(sleepTime)
+	after := Now()
+
+	require.InEpsilon(int64(sleepTime), int64(after-before), 0.05, "Interval subtraction")
+}


### PR DESCRIPTION
I opted against exposing the Go `runtime.nanotime()` routine using
unsafe trickery and instead did something far more horrific out of NIH
and wanting `CLOCK_MONOTONIC_RAW` instead of `CLOCK_MONOTONIC`.

Caveats:

 * This is quite a bit slower than what I could do if I cribbed or
   exposed the runtime routine, but the vDSO stuff is still a win.  This
   is primarily an implementation difference (I use the stack more, and
   do more math).

 * I didn't write code to parse the symbol versions.

 * vDSO support is Linux AMD64 only.

Fixes #6