### PR TITLE
wire: add consensus and get_consensus commands

### DIFF
--- a/pki/pki.go
+++ b/pki/pki.go
@@ -222,4 +222,7 @@ type Client interface {
 
 	// Post posts the node's descriptor to the PKI for the provided epoch.
 	Post(ctx context.Context, epoch uint64, signingKey *eddsa.PrivateKey, d *MixDescriptor) error
+
+	// Deserialize returns a *Document given the raw bytes
+	Deserialize(raw []byte) (*Document, error)
 }

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -217,15 +217,12 @@ type MixDescriptor struct {
 
 // Client is the abstract interface used for PKI interaction.
 type Client interface {
-	// Get returns the PKI document for the provided epoch.
-	Get(ctx context.Context, epoch uint64) (*Document, error)
+	// Get returns the PKI document along with the raw serialized form for the provided epoch.
+	Get(ctx context.Context, epoch uint64) (*Document, []byte, error)
 
 	// Post posts the node's descriptor to the PKI for the provided epoch.
 	Post(ctx context.Context, epoch uint64, signingKey *eddsa.PrivateKey, d *MixDescriptor) error
 
-	// Deserialize returns a *Document given the raw bytes
+	// Deserialize returns PKI document given the raw bytes
 	Deserialize(raw []byte) (*Document, error)
-
-	// Get returns the PKI document for the provided epoch as raw serialized bytes
-	GetRaw(ctx context.Context, epoch uint64) ([]byte, error)
 }

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -225,4 +225,7 @@ type Client interface {
 
 	// Deserialize returns a *Document given the raw bytes
 	Deserialize(raw []byte) (*Document, error)
+
+	// Get returns the PKI document for the provided epoch as raw serialized bytes
+	GetRaw(ctx context.Context, epoch uint64) ([]byte, error)
 }

--- a/wire/commands/commands.go
+++ b/wire/commands/commands.go
@@ -116,7 +116,7 @@ func getConsensusFromBytes(b []byte) (Command, error) {
 	return r, nil
 }
 
-// Consensus is a de-serialiaed consensus command.
+// Consensus is a de-serialized consensus command.
 type Consensus struct {
 	ErrorCode uint8
 	Payload   []byte

--- a/wire/commands/commands.go
+++ b/wire/commands/commands.go
@@ -77,15 +77,13 @@ func (c NoOp) ToBytes() []byte {
 	return out
 }
 
-// GetConsensus is a GET_CONSENSUS command which
-// clients can use to retreive a PKI consensus document
-// from their Provider.
+// GetConsensus is a command which clients can use to retreive a
+// cached PKI consensus document from their Provider.
 type GetConsensus struct {
 	Epoch uint64
 }
 
-// ToBytes serializes the GetConsensus,
-// returns the resulting byte slice.
+// ToBytes serializes the GetConsensus, returns the resulting byte slice.
 func (c GetConsensus) ToBytes() []byte {
 	out := make([]byte, cmdOverhead+getConsensusLength)
 	out[0] = byte(getConsensus)
@@ -104,14 +102,12 @@ func getConsensusFromBytes(b []byte) (Command, error) {
 	return r, nil
 }
 
-// Consensus is a CONSENSUS command which is used
-// to transport a cached PKI consensus file
+// Consensus is a command which is used to transport a cached PKI consensus file.
 type Consensus struct {
 	Payload []byte
 }
 
-// ToBytes serializes the GetConsensus,
-// returns the resulting byte slice.
+// ToBytes serializes the GetConsensus, returns the resulting byte slice.
 func (c Consensus) ToBytes() []byte {
 	out := make([]byte, cmdOverhead, cmdOverhead+len(c.Payload))
 	out[0] = byte(consensus)

--- a/wire/commands/commands.go
+++ b/wire/commands/commands.go
@@ -141,12 +141,6 @@ func consensusFromBytes(b []byte) (Command, error) {
 	r.Payload = make([]byte, 0, payloadSize)
 	r.Payload = append(r.Payload, b...)
 
-	// TODO: see https://github.com/katzenpost/authority/blob/master/nonvoting/client/client.go#L138
-	// // Validate the document.
-	// doc, err := s11n.VerifyAndParseDocument(b, c.cfg.PublicKey, epoch)
-	// if err != nil {
-	// 	return nil, err
-	// }
 	switch r.ErrorID {
 	case consensusOk:
 		return r, nil

--- a/wire/commands/commands.go
+++ b/wire/commands/commands.go
@@ -36,6 +36,8 @@ const (
 	messageMsgPaddingLength = sphinxConstants.SURBIDLength + constants.SphinxPlaintextHeaderLength + sphinx.SURBLength + sphinx.PayloadTagLength
 	messageEmptyLength      = messageACKLength + sphinx.PayloadTagLength + constants.ForwardPayloadLength
 
+	getConsensusLength = 8
+
 	messageTypeMessage messageType = 0
 	messageTypeACK     messageType = 1
 	messageTypeEmpty   messageType = 2
@@ -48,6 +50,8 @@ const (
 	// Implementation defined commands.
 	retreiveMessage commandID = 16
 	message         commandID = 17
+	getConsensus    commandID = 18
+	consensus       commandID = 19
 )
 
 var errInvalidCommand = errors.New("wire: invalid wire protocol command")
@@ -71,6 +75,56 @@ func (c NoOp) ToBytes() []byte {
 	out := make([]byte, cmdOverhead)
 	out[0] = byte(noOp)
 	return out
+}
+
+// GetConsensus is a GET_CONSENSUS command which
+// clients can use to retreive a PKI consensus document
+// from their Provider.
+type GetConsensus struct {
+	Epoch uint64
+}
+
+// ToBytes serializes the GetConsensus,
+// returns the resulting byte slice.
+func (c GetConsensus) ToBytes() []byte {
+	out := make([]byte, cmdOverhead+getConsensusLength)
+	out[0] = byte(getConsensus)
+	binary.BigEndian.PutUint32(out[2:6], getConsensusLength)
+	binary.BigEndian.PutUint64(out[6:14], c.Epoch)
+	return out
+}
+
+func getConsensusFromBytes(b []byte) (Command, error) {
+	if len(b) != getConsensusLength {
+		return nil, errInvalidCommand
+	}
+
+	r := new(GetConsensus)
+	r.Epoch = binary.BigEndian.Uint64(b[0:8])
+	return r, nil
+}
+
+// Consensus is a CONSENSUS command which is used
+// to transport a cached PKI consensus file
+type Consensus struct {
+	Payload []byte
+}
+
+// ToBytes serializes the GetConsensus,
+// returns the resulting byte slice.
+func (c Consensus) ToBytes() []byte {
+	out := make([]byte, cmdOverhead, cmdOverhead+len(c.Payload))
+	out[0] = byte(consensus)
+	binary.BigEndian.PutUint32(out[2:6], uint32(len(c.Payload)))
+	out = append(out, c.Payload...)
+	return out
+}
+
+func consensusFromBytes(b []byte) (Command, error) {
+	r := new(Consensus)
+	r.Payload = make([]byte, 0, len(b))
+	r.Payload = append(r.Payload, b...)
+	return r, nil
 }
 
 // Disconnect is a de-serialized disconnect command.
@@ -300,6 +354,10 @@ func FromBytes(b []byte) (Command, error) {
 		return retreiveMessageFromBytes(b)
 	case message:
 		return messageFromBytes(b)
+	case getConsensus:
+		return getConsensusFromBytes(b)
+	case consensus:
+		return consensusFromBytes(b)
 	default:
 		return nil, errInvalidCommand
 	}

--- a/wire/commands/commands_test.go
+++ b/wire/commands/commands_test.go
@@ -188,6 +188,7 @@ func TestConsensus(t *testing.T) {
 
 	cmd = &Consensus{
 		Payload: []byte{},
+		ErrorID: consensusOk,
 	}
 	b = cmd.ToBytes()
 	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
@@ -200,14 +201,25 @@ func TestConsensus(t *testing.T) {
 
 	cmd = &Consensus{
 		Payload: []byte{},
-		ErrorID: 0x01,
+		ErrorID: consensusNotFound,
 	}
 	b = cmd.ToBytes()
 	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
 	c, err = FromBytes(b)
-	require.NoError(err, "Consensus: FromBytes() failed")
+	require.Error(err, errConsensusNotFound)
 	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
 	d = c.(*Consensus)
 	require.Equal(d.Payload, cmd.Payload)
 	require.Equal(d.ErrorID, cmd.ErrorID)
+
+	cmd.ErrorID = consensusGone
+	b = cmd.ToBytes()
+	c, err = FromBytes(b)
+	require.Error(err, errConsensusGone)
+
+	cmd.ErrorID = 0xF0
+	b = cmd.ToBytes()
+	c, err = FromBytes(b)
+	require.Error(err, errInvalidCommand)
+
 }

--- a/wire/commands/commands_test.go
+++ b/wire/commands/commands_test.go
@@ -157,3 +157,28 @@ func TestMessage(t *testing.T) {
 	require.Equal(id[:], cmdMessageACK.ID[:], "MessageACK: FromBytes() ID")
 	require.Equal(ackPayload, cmdMessageACK.Payload, "MessageACK: FromBytes() Payload")
 }
+
+func TestGetConsensus(t *testing.T) {
+	require := require.New(t)
+
+	cmd := &GetConsensus{
+		Epoch: 123,
+	}
+	b := cmd.ToBytes()
+	require.Equal(getConsensusLength+cmdOverhead, len(b), "GetConsensus: ToBytes() length")
+	c, err := FromBytes(b)
+	require.NoError(err, "GetConsensus: FromBytes() failed")
+	require.IsType(cmd, c, "GetConsensus: FromBytes() invalid type")
+}
+
+func TestConsensus(t *testing.T) {
+	require := require.New(t)
+
+	cmd := &Consensus{}
+	cmd.Payload = []byte("TANSTAFL: There's ain't no such thing as a free lunch.")
+	b := cmd.ToBytes()
+	require.Equal(len(b), len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
+	c, err := FromBytes(b)
+	require.NoError(err, "Consensus: FromBytes() failed")
+	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
+}

--- a/wire/commands/commands_test.go
+++ b/wire/commands/commands_test.go
@@ -174,11 +174,31 @@ func TestGetConsensus(t *testing.T) {
 func TestConsensus(t *testing.T) {
 	require := require.New(t)
 
-	cmd := &Consensus{}
-	cmd.Payload = []byte("TANSTAFL: There's ain't no such thing as a free lunch.")
+	cmd := &Consensus{
+		Payload: []byte("TANSTAFL: There's ain't no such thing as a free lunch."),
+	}
 	b := cmd.ToBytes()
-	require.Equal(len(b), len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
+	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
 	c, err := FromBytes(b)
+	require.NoError(err, "Consensus: FromBytes() failed")
+	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
+
+	cmd = &Consensus{
+		Payload: []byte{},
+	}
+	b = cmd.ToBytes()
+	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
+	c, err = FromBytes(b)
+	require.NoError(err, "Consensus: FromBytes() failed")
+	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
+
+	cmd = &Consensus{
+		Payload: []byte{},
+		ErrorID: 0x01,
+	}
+	b = cmd.ToBytes()
+	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
+	c, err = FromBytes(b)
 	require.NoError(err, "Consensus: FromBytes() failed")
 	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
 }

--- a/wire/commands/commands_test.go
+++ b/wire/commands/commands_test.go
@@ -182,6 +182,9 @@ func TestConsensus(t *testing.T) {
 	c, err := FromBytes(b)
 	require.NoError(err, "Consensus: FromBytes() failed")
 	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
+	d := c.(*Consensus)
+	require.Equal(d.Payload, cmd.Payload)
+	require.Equal(d.ErrorID, cmd.ErrorID)
 
 	cmd = &Consensus{
 		Payload: []byte{},
@@ -191,6 +194,9 @@ func TestConsensus(t *testing.T) {
 	c, err = FromBytes(b)
 	require.NoError(err, "Consensus: FromBytes() failed")
 	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
+	d = c.(*Consensus)
+	require.Equal(d.Payload, cmd.Payload)
+	require.Equal(d.ErrorID, cmd.ErrorID)
 
 	cmd = &Consensus{
 		Payload: []byte{},
@@ -201,4 +207,7 @@ func TestConsensus(t *testing.T) {
 	c, err = FromBytes(b)
 	require.NoError(err, "Consensus: FromBytes() failed")
 	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
+	d = c.(*Consensus)
+	require.Equal(d.Payload, cmd.Payload)
+	require.Equal(d.ErrorID, cmd.ErrorID)
 }

--- a/wire/commands/commands_test.go
+++ b/wire/commands/commands_test.go
@@ -176,50 +176,25 @@ func TestConsensus(t *testing.T) {
 
 	cmd := &Consensus{
 		Payload: []byte("TANSTAFL: There's ain't no such thing as a free lunch."),
+		ErrorCode: ConsensusOk,
 	}
 	b := cmd.ToBytes()
-	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
+	require.Len(b, consensusBaseLength+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
 	c, err := FromBytes(b)
 	require.NoError(err, "Consensus: FromBytes() failed")
 	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
 	d := c.(*Consensus)
 	require.Equal(d.Payload, cmd.Payload)
-	require.Equal(d.ErrorID, cmd.ErrorID)
+	require.Equal(d.ErrorCode, cmd.ErrorCode)
 
-	cmd = &Consensus{
-		Payload: []byte{},
-		ErrorID: consensusOk,
-	}
+	cmd.Payload = nil
+	cmd.ErrorCode = ConsensusNotFound // Just set it to something non 0.
 	b = cmd.ToBytes()
-	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
+	require.Len(b, consensusBaseLength+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
 	c, err = FromBytes(b)
 	require.NoError(err, "Consensus: FromBytes() failed")
 	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
 	d = c.(*Consensus)
 	require.Equal(d.Payload, cmd.Payload)
-	require.Equal(d.ErrorID, cmd.ErrorID)
-
-	cmd = &Consensus{
-		Payload: []byte{},
-		ErrorID: consensusNotFound,
-	}
-	b = cmd.ToBytes()
-	require.Equal(len(b), 1+len(cmd.Payload)+cmdOverhead, "GetConsensus: ToBytes() length")
-	c, err = FromBytes(b)
-	require.Error(err, errConsensusNotFound)
-	require.IsType(cmd, c, "Consensus: FromBytes() invalid type")
-	d = c.(*Consensus)
-	require.Equal(d.Payload, cmd.Payload)
-	require.Equal(d.ErrorID, cmd.ErrorID)
-
-	cmd.ErrorID = consensusGone
-	b = cmd.ToBytes()
-	c, err = FromBytes(b)
-	require.Error(err, errConsensusGone)
-
-	cmd.ErrorID = 0xF0
-	b = cmd.ToBytes()
-	c, err = FromBytes(b)
-	require.Error(err, errInvalidCommand)
-
+	require.Equal(d.ErrorCode, cmd.ErrorCode)
 }


### PR DESCRIPTION
* Add wire protocol commands for sending/retrieving PKI consensus documents so that we can implement the Provider PKI caching.

* Add PKI interface methods:
1. get raw: returns the document as raw serialized bytes
This is needed by the PKI caching Provider so that the raw document bytes can be obtained without reaching into the authority library.
2. deserialize: deserializes document from raw bytes
This is needed by clients downloading the consensus from a PKI caching Provider.

If the PKI consensus documents grow too big because of network size then we'll need to add a fragmentation scheme to this...