### PR TITLE
Implement importing ecdh.PublicKey from PEM file.

### DIFF
--- a/crypto/ecdh/ecdh.go
+++ b/crypto/ecdh/ecdh.go
@@ -140,6 +140,25 @@ func (k *PublicKey) ToPEMFile(f string) error {
 	return ioutil.WriteFile(f, pem.EncodeToMemory(blk), 0600)
 }
 
+// FromPEMFile reads the PublicKey from a PEM file at path f.
+func (k *PublicKey) FromPEMFile(f string) error {
+	const keyType = "X25519 PUBLIC KEY"
+
+	buf, err := ioutil.ReadFile(f)
+	if err != nil {
+		return err
+	}
+	blk, _ := pem.Decode(buf)
+	if blk == nil {
+		return fmt.Errorf("ecdh: failed to decode PEM file %v", f)
+	}
+	if blk.Type != keyType {
+		return fmt.Errorf("ecdh: attempted to decode PEM file with wrong key type!")
+	}
+	err = k.FromBytes(blk.Bytes)
+	return err
+}
+
 func (k *PublicKey) rebuildHexString() {
 	k.hexString = strings.ToUpper(hex.EncodeToString(k.pubBytes[:]))
 }

--- a/crypto/ecdh/ecdh.go
+++ b/crypto/ecdh/ecdh.go
@@ -155,8 +155,7 @@ func (k *PublicKey) FromPEMFile(f string) error {
 	if blk.Type != keyType {
 		return fmt.Errorf("ecdh: attempted to decode PEM file with wrong key type!")
 	}
-	err = k.FromBytes(blk.Bytes)
-	return err
+	return k.FromBytes(blk.Bytes)
 }
 
 func (k *PublicKey) rebuildHexString() {

--- a/crypto/ecdh/ecdh_test.go
+++ b/crypto/ecdh/ecdh_test.go
@@ -18,6 +18,7 @@ package ecdh
 
 import (
 	"crypto/rand"
+	"io/ioutil"
 	"testing"
 
 	"github.com/katzenpost/core/utils"
@@ -70,4 +71,17 @@ func TestECDHOps(t *testing.T) {
 	copy(tmp[:], aliceKeypair.PublicKey().Bytes())
 	curve25519.ScalarMult(&bobS, &bobSk, &tmp)
 	assert.Equal(bobS, aliceS, "Exp() mismatch against X25519 scalar mult")
+}
+
+func TestPublicKeyToFromPEMFile(t *testing.T) {
+	assert := assert.New(t)
+	aliceKeypair, err := NewKeypair(rand.Reader)
+	f, err := ioutil.TempFile("", "alice.pem")
+	assert.NoError(err)
+	err = aliceKeypair.PublicKey().ToPEMFile(f.Name())
+	assert.NoError(err)
+	pubKey := new(PublicKey)
+	err = pubKey.FromPEMFile(f.Name())
+	assert.NoError(err)
+	assert.Equal(pubKey.Bytes(), aliceKeypair.PublicKey().Bytes())
 }


### PR DESCRIPTION
Add functionality to load ecdh.PublicKey from PEM file and unit test for
ecdh.PublicKey.ToPEMFile and ecdh.PublicKey.FromPEMFile methods.