### PR TITLE
Use base64 encoding

### DIFF
--- a/crypto/ecdh/ecdh.go
+++ b/crypto/ecdh/ecdh.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/katzenpost/core/utils"
 	"golang.org/x/crypto/curve25519"
@@ -49,7 +48,7 @@ var errInvalidKey = errors.New("ecdh: invalid key")
 // PublicKey is a ECDH public key.
 type PublicKey struct {
 	pubBytes  [GroupElementLength]byte
-	hexString string
+	b64String string
 }
 
 // Bytes returns the raw public key.
@@ -64,7 +63,7 @@ func (k *PublicKey) FromBytes(b []byte) error {
 	}
 
 	copy(k.pubBytes[:], b)
-	k.rebuildHexString()
+	k.rebuildB64String()
 
 	return nil
 }
@@ -101,7 +100,7 @@ func (k *PublicKey) UnmarshalText(data []byte) error {
 // in memory.
 func (k *PublicKey) Reset() {
 	utils.ExplicitBzero(k.pubBytes[:])
-	k.hexString = "[scrubbed]"
+	k.b64String = "[scrubbed]"
 }
 
 // Blind blinds the public key with the provided blinding factor.
@@ -109,9 +108,9 @@ func (k *PublicKey) Blind(blindingFactor *[GroupElementLength]byte) {
 	Exp(&k.pubBytes, &k.pubBytes, blindingFactor)
 }
 
-// String returns the public key as a hexdecimal encoded string.
+// String returns the public key as a base64 encoded string.
 func (k *PublicKey) String() string {
-	return k.hexString
+	return k.b64String
 }
 
 // FromString deserializes the string s into the PublicKey.
@@ -158,8 +157,8 @@ func (k *PublicKey) FromPEMFile(f string) error {
 	return k.FromBytes(blk.Bytes)
 }
 
-func (k *PublicKey) rebuildHexString() {
-	k.hexString = strings.ToUpper(hex.EncodeToString(k.pubBytes[:]))
+func (k *PublicKey) rebuildB64String() {
+	k.b64String = base64.StdEncoding.EncodeToString(k.Bytes())
 }
 
 // Equal returns true iff the public key is byte for byte identical.
@@ -186,7 +185,7 @@ func (k *PrivateKey) FromBytes(b []byte) error {
 
 	copy(k.privBytes[:], b)
 	expG(&k.pubKey.pubBytes, &k.privBytes)
-	k.pubKey.rebuildHexString()
+	k.pubKey.rebuildB64String()
 
 	return nil
 }
@@ -217,7 +216,7 @@ func NewKeypair(r io.Reader) (*PrivateKey, error) {
 	}
 
 	expG(&k.pubKey.pubBytes, &k.privBytes)
-	k.pubKey.rebuildHexString()
+	k.pubKey.rebuildB64String()
 
 	return k, nil
 }

--- a/wire/commands/commands_test.go
+++ b/wire/commands/commands_test.go
@@ -291,24 +291,24 @@ func TestReveal(t *testing.T) {
 
 	alice, err := eddsa.NewKeypair(rand.Reader)
 	require.NoError(err, "wtf")
-	var digest [32]byte
+	digest := make([]byte, 32)
 	for i := 0; i < 32; i++ {
 		digest[i] = uint8(i)
 	}
 	cmd := &Reveal{
 		Epoch:     3141,
 		PublicKey: alice.PublicKey(),
-		Digest:    digest,
+		Payload:   digest,
 	}
 	b := cmd.ToBytes()
-	require.Len(b, cmdOverhead+revealOverhead, "Reveal: ToBytes() length")
+	require.Len(b, cmdOverhead+revealOverhead+32, "Reveal: ToBytes() length")
 	c, err := FromBytes(b)
 	require.NoError(err, "Reveal: FromBytes() failed")
 	require.IsType(cmd, c, "Reveal: FromBytes() invalid type")
 	d := c.(*Reveal)
 	require.Equal(d.Epoch, cmd.Epoch)
 	require.Equal(d.PublicKey.Bytes(), cmd.PublicKey.Bytes())
-	require.Equal(d.Digest, cmd.Digest)
+	require.Equal(d.Payload, cmd.Payload)
 }
 
 func TestRevealtatus(t *testing.T) {


### PR DESCRIPTION
Use base64 strings for key String() method because we support both and base64 is more compact and easier on the eyes in debug logs.