### PR TITLE
queue: Make Enqueue consistent with other methods

### DIFF
--- a/queue/priority_queue.go
+++ b/queue/priority_queue.go
@@ -114,6 +114,7 @@ func (q *PriorityQueue) Enqueue(priority uint64, value interface{}) {
 		Value:    value,
 		Priority: priority,
 	}
+	q.m[ent.Priority] = q.Len()
 	heap.Push(q, ent)
 }
 


### PR DESCRIPTION
That is to say, the Enqueue method should create a map entry
for the item's priority just like Push does.