### PR TITLE
Check for assigned errors in test

### DIFF
--- a/wire/commands/commands_vectors_test.go
+++ b/wire/commands/commands_vectors_test.go
@@ -151,12 +151,14 @@ func TestCommandVectors(t *testing.T) {
 	noOpBytes, err := hex.DecodeString(cmdsTest.NoOp)
 	assert.NoError(err)
 	cmd, err := FromBytes(noOpBytes)
+	assert.NoError(err)
 	_, ok := cmd.(*NoOp)
 	assert.True(ok)
 
 	disconnectBytes, err := hex.DecodeString(cmdsTest.Disconnect)
 	assert.NoError(err)
 	cmd, err = FromBytes(disconnectBytes)
+	assert.NoError(err)
 	_, ok = cmd.(*Disconnect)
 	assert.True(ok)
 


### PR DESCRIPTION
Since we assign a value to err, but don't check its value, we should
either remove the assignment - or simply check its value. I've opted
for the latter as it certainly can't harm.