### PR TITLE
Fix nil dereference when log.Disable is true

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -34,6 +34,10 @@ type discardCloser struct {
 	discard io.Writer
 }
 
+func (d *discardCloser) Write(msg []byte) (int, error) {
+	return d.discard.Write(msg)
+}
+
 func (d *discardCloser) Close() error {
 	return nil
 }


### PR DESCRIPTION
Hi there,

Thanks for this great mix network, it works great.

However, I execute server/docker with log.Disable enabled. I always see these error (panic for nil pointer dereference):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x12139f2]

goroutine 40 [running]:
testing.tRunner.func1.1(0x1846380, 0x1ebe660)
        /usr/local/Cellar/go/1.15.8/libexec/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc00024e180)
        /usr/local/Cellar/go/1.15.8/libexec/src/testing/testing.go:1075 +0x41a
panic(0x1846380, 0x1ebe660)
        /usr/local/Cellar/go/1.15.8/libexec/src/runtime/panic.go:969 +0x1b9
github.com/katzenpost/core/log.(*discardCloser).Write(0xc000208660, 0xc0002383f0, 0x70, 0x70, 0x6f, 0xc0002383f0, 0x0)
        <autogenerated>:1 +0x32
log.(*Logger).Output(0xc0002205a0, 0x6, 0xc000238380, 0x6f, 0x0, 0x0)
        /usr/local/Cellar/go/1.15.8/libexec/src/log/log.go:181 +0x284
gopkg.in/op/go-logging%2ev1.(*LogBackend).Log(0xc000212960, 0x3, 0x4, 0xc0002521b0, 0xc0000cfaf8, 0x1211c60)
        ~/go/pkg/mod/gopkg.in/op/go-logging.v1@v1.0.0-20160211212156-b2cb9fa56473/log_nix.go:75 +0x2ba
gopkg.in/op/go-logging%2ev1.(*backendFormatter).Log(0xc0002086e0, 0x3, 0x3, 0xc000252120, 0xc00020cff8, 0x1ed7b01)
        ~/go/pkg/mod/gopkg.in/op/go-logging.v1@v1.0.0-20160211212156-b2cb9fa56473/format.go:399 +0xbe
gopkg.in/op/go-logging%2ev1.(*moduleLeveled).Log(0xc00021a840, 0x3, 0x2, 0xc000252120, 0x1010478, 0x90)
        ~/go/pkg/mod/gopkg.in/op/go-logging.v1@v1.0.0-20160211212156-b2cb9fa56473/level.go:116 +0xeb
github.com/katzenpost/core/log.(*Backend).Log(0xc000223f10, 0x3, 0x2, 0xc000252120, 0x0, 0x0)
        ~/go/pkg/mod/github.com/katzenpost/core@v0.0.12/log/log.go:69 +0x95
gopkg.in/op/go-logging%2ev1.(*Logger).log(0xc0002129c0, 0x3, 0x1955913, 0x55, 0x0, 0x0, 0x0)
        ~/go/pkg/mod/gopkg.in/op/go-logging.v1@v1.0.0-20160211212156-b2cb9fa56473/logger.go:158 +0x194
gopkg.in/op/go-logging%2ev1.(*Logger).Notice(...)
        ~/go/pkg/mod/gopkg.in/op/go-logging.v1@v1.0.0-20160211212156-b2cb9fa56473/logger.go:219
github.com/katzenpost/server.New(0xc000212870, 0x0, 0x0, 0x0)
        ~/Desktop/projects/hashcloak/server/server.go:233 +0x1d9
github.com/katzenpost/server.TestServerStartShutdown(0xc00024e180)
        ~/Desktop/projects/hashcloak/server/server_shutdown_test.go:93 +0x4df
testing.tRunner(0xc00024e180, 0x195fed8)
        /usr/local/Cellar/go/1.15.8/libexec/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
        /usr/local/Cellar/go/1.15.8/libexec/src/testing/testing.go:1168 +0x2b3
```

After trace source code, the reason might be missing `Write` function in `discardCloser`.

I add the Write function in this PR.